### PR TITLE
[#82] feature : wav to raw, 변환 후 api 호출 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation 'com.google.code.gson:gson:2.8.9' // JSON 처리를 위한 예시 (필요 시 삭제)
 	implementation 'javazoom:jlayer:1.0.1' // JLayer (javazoom) 라이브러리 추가
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation 'com.google.code.gson:gson:2.8.9' // JSON 처리를 위한 예시 (필요 시 삭제)
+	implementation 'javazoom:jlayer:1.0.1' // JLayer (javazoom) 라이브러리 추가
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/speech/up/api/converter/WavToRaw.java
+++ b/src/main/java/com/speech/up/api/converter/WavToRaw.java
@@ -1,0 +1,85 @@
+package com.speech.up.api.converter;
+
+import javax.sound.sampled.*;
+import java.io.*;
+import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class WavToRaw {
+
+	private static final Logger log = LoggerFactory.getLogger(WavToRaw.class);
+	private static final AudioFormat FORMAT = new AudioFormat(16000, 16, 1, true, false);
+	private static final int HEADER_SIZE = 44; // WAV 파일 헤더 크기
+
+	public WavToRaw() {
+		super();
+	}
+
+	// WAV 파일을 읽어 PCM 데이터를 바이트 배열로 반환
+	public byte[] convertToRawPcm(File file) throws UnsupportedAudioFileException, IOException {
+		try (AudioInputStream sourceStream = AudioSystem.getAudioInputStream(file)) {
+			AudioFormat sourceFormat = sourceStream.getFormat();
+			AudioFormat targetFormat = new AudioFormat(
+				AudioFormat.Encoding.PCM_SIGNED,
+				16000,
+				16,
+				1,
+				2,
+				16000,
+				false
+			);
+
+			if (!AudioSystem.isConversionSupported(targetFormat, sourceFormat)) {
+				throw new UnsupportedAudioFileException("The source format is not supported.");
+			}
+
+			try (AudioInputStream convertedStream = AudioSystem.getAudioInputStream(targetFormat, sourceStream);
+				 ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+
+				byte[] buffer = new byte[1024];
+				int bytesRead;
+				while ((bytesRead = convertedStream.read(buffer)) != -1) {
+					byteArrayOutputStream.write(buffer, 0, bytesRead);
+				}
+
+				// WAV 헤더를 제거하고 PCM 데이터만 반환
+				byte[] rawPcmData = byteArrayOutputStream.toByteArray();
+				return formatWav2Raw(rawPcmData);
+			}
+		}
+	}
+
+	// WAV 헤더를 제거하고 PCM 데이터만 반환
+	public byte[] formatWav2Raw(@NotNull final byte[] audioFileContent) {
+		return Arrays.copyOfRange(audioFileContent, HEADER_SIZE, audioFileContent.length);
+	}
+
+	// 오디오 데이터를 바이트 배열로 읽어들임
+	public byte[] AudioToByte(File file) {
+		byte[] audioBytes = new byte[0];
+
+		try (FileInputStream fileStream = new FileInputStream(file);
+			 BufferedInputStream in = new BufferedInputStream(fileStream);
+			 ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+
+			byte[] buffer = new byte[1024];
+			int read;
+
+			while ((read = in.read(buffer)) > 0) {
+				out.write(buffer, 0, read);
+			}
+
+			audioBytes = out.toByteArray();
+		} catch (FileNotFoundException ignored) {
+			log.info("File not found: {}", ignored.getMessage());
+		} catch (IOException ioe) {
+			log.info("IO error occurred: {}", ioe.getMessage());
+		}
+
+		return audioBytes;
+	}
+}

--- a/src/test/java/com/speech/up/script/service/ScriptServiceTest.java
+++ b/src/test/java/com/speech/up/script/service/ScriptServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 import com.speech.up.script.entity.ScriptEntity;
 import com.speech.up.script.repository.ScriptRepository;
@@ -27,6 +28,7 @@ import com.speech.up.user.entity.UserEntity;
 import com.speech.up.user.repository.UserRepository;
 
 import jakarta.persistence.EntityListeners;
+import jakarta.servlet.http.HttpServletRequest;
 
 @EntityListeners(AuditingEntityListener.class)
 public class ScriptServiceTest {
@@ -125,7 +127,7 @@ public class ScriptServiceTest {
 	@Test
 	public void getScriptListTest() {
 	    // Given
-	    Long id = 1L;
+	    HttpServletRequest id = new MockHttpServletRequest();
 		Long userId = 1L;
 		ScriptEntity scriptEntity = new ScriptEntity("test", userEntity,  "", true);
 		List<ScriptEntity> activeScripts = Collections.singletonList(scriptEntity);

--- a/src/test/java/com/speech/up/script/service/ScriptServiceTest.java
+++ b/src/test/java/com/speech/up/script/service/ScriptServiceTest.java
@@ -73,26 +73,29 @@ public class ScriptServiceTest {
 		);
 
 		scriptEntity = new ScriptEntity(
-			"content",userEntity,false
+			"content",userEntity,"",false
 		);
 
 
 		scriptUpdateRequestDto = new ScriptUpdateDto.Request(
 			1L,
 			"content",
+			"",
 			userEntity,
-			true
+			false
 		);
 
 		scriptAddRequestDto = new ScriptAddDto.Request(
 			"content",
-			userEntity
+			userEntity,
+			""
 		);
 
 		scriptIsUseRequestDto = new ScriptIsUseDto.Request(
 			1L,
 			true,
 			"content",
+			"",
 			userEntity
 		);
 


### PR DESCRIPTION
- pcm 형식 wav 파일에서 원시데이터 파일로 변환하는 기능을 추가
- 원시파일을 바로 api 호출시 requestBody에 넣을 수 있도록 수정

## TODO
- mp3를 지정된 포맷으로 설정된 pcm 파일로 변환하는 기능